### PR TITLE
ci: Cache pip packages, switch to Ubuntu Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 os: linux
+dist: bionic
+
 jobs:
   include:
     - language: python
       python: 3.7
-      install:
-        - pip install pipenv
-        - pipenv install
+      cache: pip
+      install: "pip install $(pipenv lock --requirements)"
       script: docs/build_docs.sh
 
 notifications:
   irc:
     channels:
       - "ircs://chat.freenode.net:6697/##jwf"
-      - "ircs://chat.freenode.net:5597/#rit-librecorps"
     template:
       - "[%{repository_name}:%{branch}@%{commit} - build #%{build_number}] CI %{result}! (%{build_url})"
     on_success: change


### PR DESCRIPTION
Minor improvements to the CI pipeline. Take advantage of the `pip` cache
in Travis to speed up build time when dependencies haven't changed. Also
switch to the newest Linux distribution option available. Stay ahead of
the ball, folx.